### PR TITLE
Revert "Use Float64 by default for better accuracy (#6)"

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -1,8 +1,9 @@
-function create_object(path::String; gridspacing::Real, density::Real=1, datatype::Type{T}=Float64, verbose::Bool=false) where {T}
+function create_object(path::String; gridspacing::Real, density::Real=1, verbose::Bool=false)
     @assert endswith(path, ".stl")
-    surface_mesh = FileIO.load(path; pointtype=Point{3,T})
+    surface_mesh = FileIO.load(path)
     grid = Grid(gridspacing, surface_mesh)
     levelset = generate_levelset(surface_mesh, grid; verbose)
+    T = eltype(levelset.ϕ)
     LevelSetObject(levelset; density=T(density))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,8 +31,8 @@ using StaticArrays
         @test LevelSetObjects.centroid(obj) ≈ c rtol=0.04
         @test LevelSetObjects.moment_of_inertia(obj) ≈ I rtol=0.04
         # check moment of inertia for other axes
-        @test LevelSetObjects.moment_of_inertia_per_density(obj.levelset, SVector(1000.0,1000.0,0.0)) ≈ [(3/5)*m*h^2+(3/20)*m*r^2 0 0; 0 (3/5)*m*h^2+(3/20)*m*r^2 0; 0 0 (3/10)*m*r^2] rtol=0.04
-        @test LevelSetObjects.moment_of_inertia_per_density(obj.levelset, SVector(1000.0,1000.0,h)) ≈ [(1/10)*m*h^2+(3/20)*m*r^2 0 0; 0 (1/10)*m*h^2+(3/20)*m*r^2 0; 0 0 (3/10)*m*r^2] rtol=0.04
+        @test LevelSetObjects.moment_of_inertia_per_density(obj.levelset, SVector{3,Float32}(1000,1000,0)) ≈ [(3/5)*m*h^2+(3/20)*m*r^2 0 0; 0 (3/5)*m*h^2+(3/20)*m*r^2 0; 0 0 (3/10)*m*r^2] rtol=0.04
+        @test LevelSetObjects.moment_of_inertia_per_density(obj.levelset, SVector{3,Float32}(1000,1000,h)) ≈ [(1/10)*m*h^2+(3/20)*m*r^2 0 0; 0 (1/10)*m*h^2+(3/20)*m*r^2 0; 0 0 (3/10)*m*r^2] rtol=0.04
     end
     @testset "Tube" begin
         obj = LevelSetObjects.create_object("tube.stl"; gridspacing=50.0)


### PR DESCRIPTION
This reverts commit b8cc07280a3e0003ffabae15ad5c718620f29059.